### PR TITLE
Refactor drag-drop component to use button layout

### DIFF
--- a/src/app/drag-drop/drag-drop.component.css
+++ b/src/app/drag-drop/drag-drop.component.css
@@ -1,4 +1,4 @@
-.upload-container{display:flex;width:100%;max-width:304px;padding:20px 10px;flex-direction:column;align-items:center;gap:8px;border-radius:4px;border:1px dashed #C8C8C8;background:#FFF;cursor:pointer;transition:border-color .2s ease}
-.upload-container:hover{border-color:#629D37}
-.upload-icon{width:30px;height:30px}
-.upload-text{color:#999;text-align:center;font-family:Inter;font-size:13px;font-weight:400;line-height:24px}
+.upload-wrapper{display:inline-flex;align-items:center;gap:12px;width:auto;min-width:235px;height:32px}
+.select-file-btn{display:flex;height:32px;padding:8px 16px;justify-content:center;align-items:center;gap:4px;border-radius:8px;border:1px solid #629D37;background:#FFF;color:#629D37;font-family:Inter;font-size:14px;font-weight:700;line-height:normal;cursor:pointer;transition:all .2s ease}
+.select-file-btn:hover{background:color-mix(in srgb,#629D37 5%,transparent)}
+.drop-text{color:#000;font-family:Inter;font-size:13px;font-weight:400;line-height:24px}

--- a/src/app/drag-drop/drag-drop.component.html
+++ b/src/app/drag-drop/drag-drop.component.html
@@ -1,14 +1,10 @@
-<div class="upload-container"
-     (click)="fileInput.click()"
+<div class="upload-wrapper"
      (dragover)="onDragOver($event)"
      (dragleave)="onDragLeave($event)"
      (drop)="onDrop($event)">
-  <svg class="upload-icon" width="30" height="30" viewBox="0 0 30 30" fill="none">
-    <path d="M21.847 11.2638C21.8563 11.2638 21.8656 11.2638 21.875 11.2638C24.9816 11.2638 27.5 13.7868 27.5 16.8991C27.5 19.7998 25.3125 22.1885 22.5 22.5M21.847 11.2638C21.8655 11.0576 21.875 10.8487 21.875 10.6376C21.875 6.83369 18.797 3.75 15 3.75C11.404 3.75 8.45291 6.51584 8.15053 10.0399M21.847 11.2638C21.7191 12.6845 21.1607 13.9808 20.3035 15.0206M8.15053 10.0399C4.97998 10.3422 2.5 13.0174 2.5 16.2729C2.5 19.3021 4.6472 21.829 7.5 22.4091M8.15053 10.0399C8.34783 10.0211 8.54779 10.0115 8.75 10.0115C10.1573 10.0115 11.4559 10.4774 12.5006 11.2638" stroke="#629D37" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M15 16.25V26.25M15 16.25C14.1247 16.25 12.4894 18.7429 11.875 19.375M15 16.25C15.8753 16.25 17.5106 18.7429 18.125 19.375" stroke="#629D37" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-  </svg>
-  <div class="upload-text">
-    Ziehen & Ablegen<br>oder klicken, um eine Datei auszuwählen
-  </div>
+  <button class="select-file-btn" type="button" (click)="fileInput.click()">
+    Select a file
+  </button>
+  <span class="drop-text">or Drop a file here</span>
   <input #fileInput type="file" multiple (change)="onFileInputChange($event)" style="display:none" />
 </div>

--- a/src/app/note-dialog/note-dialog.component.css
+++ b/src/app/note-dialog/note-dialog.component.css
@@ -4,10 +4,6 @@
 .field-label{display:block;font-size:.9rem;color:var(--gray-700);margin-bottom:4px}
 .note-input{width:100%;resize:vertical;border:1px solid var(--color-stroke-input-primary,#c8c8c8);border-radius:8px;padding:.625rem;font:inherit;color:var(--gray-900)}
 .file-section{margin-top:.25rem}
-.upload-container{display:flex;width:100%;max-width:304px;padding:20px 10px;flex-direction:column;align-items:center;gap:8px;border-radius:4px;border:1px dashed #C8C8C8;background:#FFF;cursor:pointer;transition:border-color .2s ease}
-.upload-container:hover{border-color:#629D37}
-.upload-icon{width:30px;height:30px}
-.upload-text{color:#999;text-align:center;font-family:Inter;font-size:13px;font-weight:400;line-height:24px}
 .file-list{list-style:none;margin:.5rem 0 0 0;padding:0;display:flex;flex-direction:column;gap:.5rem}
 .file-item{display:flex;align-items:center;justify-content:space-between;background:color-mix(in srgb,var(--pill-accent,var(--bright-blue)) 5%,transparent);padding:.5rem .75rem;border-radius:8px}
 .file-name{color:var(--gray-900)}


### PR DESCRIPTION
## Changes Made

### HTML Template Updates
- Replaced large upload container with compact horizontal layout using `upload-wrapper` class
- Removed SVG upload icon and descriptive text
- Added dedicated "Select a file" button with click handler
- Simplified drop text to "or Drop a file here"
- Maintained drag and drop event handlers on wrapper element

### CSS Style Changes
- **Removed styles**: `.upload-container`, `.upload-icon`, `.upload-text` classes
- **Added styles**:
  - `.upload-wrapper`: Horizontal flex layout with 12px gap, auto width, 32px height
  - `.select-file-btn`: Styled button with green border, hover effects, and proper typography
  - `.drop-text`: Simple text styling for drop instruction

### File Cleanup
- Removed duplicate CSS rules from `note-dialog.component.css` that were previously copied from drag-drop component

The component now uses a more compact button-based interface while preserving all drag-and-drop functionality.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d6870992916d4a5d9918017b035ef5b0/flare-sanctuary)

👀 [Preview Link](https://d6870992916d4a5d9918017b035ef5b0-flare-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d6870992916d4a5d9918017b035ef5b0</projectId>-->
<!--<branchName>flare-sanctuary</branchName>-->